### PR TITLE
Use platform module to test and enforce Python 3.5 or newer.

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,5 +1,11 @@
 #!/usr/bin/env python
 
+# Leave here so we can do python version tests first.
+import platform
+if platform.python_version_tuple()[0] < 3 and \
+        platform.python_version_tuple()[1] < 5:
+    raise EnvironmentError("Python versions before 3.5 are not supported.")
+
 import app.console
 import app.net
 import app.tor


### PR DESCRIPTION
Enforce Python 3.5 or newer (based on the versions listed in the README.md file's python version compatibility image).

This utilizes the in-build `platform` module to evaluate the tuple of the Python version in use, in order to enforce >= 3.5 (`major version < 3` will error out, `major version = 3` and `minor version < 5` will raise an `EnvironmentError`).